### PR TITLE
Fix offset issue where timezone offsets were inverted

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,23 +2,23 @@ import { format, parse } from "./index";
 
 describe("exif date", () => {
   it("should parse", () => {
-    expect(parse("2016:07:11 21:33:20").toISOString()).toEqual(
-      "2016-07-11T21:33:20.000Z"
+    expect(parse("2016:07:11 21:33:20")).toEqual(
+      new Date("2016-07-11T21:33:20.000Z")
     );
-    expect(parse("2016:07:11 21:33:20.71").toISOString()).toEqual(
-      "2016-07-11T21:33:20.071Z"
+    expect(parse("2016:07:11 21:33:20.71")).toEqual(
+      new Date("2016-07-11T21:33:20.071Z")
     );
-    expect(parse("2015:03:19 19:03:50Z").toISOString()).toEqual(
-      "2015-03-19T19:03:50.000Z"
+    expect(parse("2015:03:19 19:03:50Z")).toEqual(
+      new Date("2015-03-19T19:03:50.000Z")
     );
-    expect(parse("2013:10:06 18:55:39.114").toISOString()).toEqual(
-      "2013-10-06T18:55:39.114Z"
+    expect(parse("2013:10:06 18:55:39.114")).toEqual(
+      new Date("2013-10-06T18:55:39.114Z")
     );
-    expect(parse("2016:08:22 13:41:47+10:00").toISOString()).toEqual(
-      "2016-08-22T23:41:47.000Z"
+    expect(parse("2016:08:22 13:41:47+10:00")).toEqual(
+      new Date("2016-08-22T13:41:47.000+10:00")
     );
-    expect(parse("2016:08:22 13:41:47-10:00").toISOString()).toEqual(
-      "2016-08-22T03:41:47.000Z"
+    expect(parse("2016:08:22 13:41:47-10:00")).toEqual(
+      new Date("2016-08-22T13:41:47.000-10:00")
     );
     expect(parse("not a date").getTime()).toEqual(NaN);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export function parse(value: string): Date {
   const offset = m[8]
     ? 0
     : m[9]
-    ? (Number(m[10]) * 60 + Number(m[11])) * (m[9] === "+" ? 1 : -1)
+    ? (Number(m[10]) * 60 + Number(m[11])) * (m[9] === "+" ? -1 : 1)
     : 0;
 
   date.setUTCFullYear(Number(m[1]));


### PR DESCRIPTION
The timezone offset is currently being applied in the wrong direction. This PR inverses that offset, as well as updates the `parse` tests to display timezones for returned dates to make it clearer.

Given the following:
```js
const exifString = "2016:08:22 13:41:47+10:00";
const jsDateString = "2016-08-22T13:41:47.000+10:00";
```

**Expected behavior**
These two strings represent the same time, and should be equivalent.

**Actual behavior**
Parsing the `exifString` results in a time that is 20 hours off from the `jsDateString`.
```js
console.log(parse(exifString)) // 2016-08-22T23:41:47.000Z
console.log(new Date(jsDateString)) // 2016-08-22T03:41:47.000Z
```

**Longer explanation of the bug**
I'm writing out a longer explanation mostly to explain it to myself, but it might help anyone else too. I live in the `-04:00` timezone, so if it's 12:00:00 in UTC, it's 08:00:00 for me. In order to calculate a UTC date for myself, I need to _add_ 4 hours rather than subtract, because my UTC time would be 4 hours after my own, so 8 + 4 => 12.